### PR TITLE
Allow 'player.*' cmds to work with many players

### DIFF
--- a/src/main/java/net/zhuoweizhang/raspberryjuice/RaspberryJuicePlugin.java
+++ b/src/main/java/net/zhuoweizhang/raspberryjuice/RaspberryJuicePlugin.java
@@ -68,7 +68,7 @@ public class RaspberryJuicePlugin extends JavaPlugin implements Listener {
 	public Player getHostPlayer() {
 		if (hostPlayer != null) return hostPlayer;
 		Player[] allPlayers = getServer().getOnlinePlayers();
-		if (allPlayers.length == 1) 
+		if (allPlayers.length >= 1) 
 			return allPlayers[0];
 		return null;
 	}


### PR DESCRIPTION
If there is no host player and multiple players connect, the old behavior would hang on all player.\* commands. The new behavior picks the first player in the list returned by getOnlinePlayers() and applies player.\* commands to that player.

This isn't ideal but at least it won't hang.
