### PR TITLE
Fix for #21: Missing aliases for WATER and LAVA in block.py

### DIFF
--- a/src/main/resources/mcpi/api/python/mcpi/block.py
+++ b/src/main/resources/mcpi/api/python/mcpi/block.py
@@ -17,6 +17,10 @@ class Block:
         """Allows a Block to be sent whenever id [and data] is needed"""
         return iter((self.id, self.data))
 
+    def __repr__(self):
+        return "Block(%d, %d)"%(self.id, self.data)
+
+
 AIR                 = Block(0)
 STONE               = Block(1)
 GRASS               = Block(2)
@@ -26,8 +30,10 @@ WOOD_PLANKS         = Block(5)
 SAPLING             = Block(6)
 BEDROCK             = Block(7)
 WATER_FLOWING       = Block(8)
+WATER               = WATER_FLOWING
 WATER_STATIONARY    = Block(9)
 LAVA_FLOWING        = Block(10)
+LAVA                = LAVA_FLOWING
 LAVA_STATIONARY     = Block(11)
 SAND                = Block(12)
 GRAVEL              = Block(13)


### PR DESCRIPTION
Updated block.py to bring it up to date with the official release, setting aliases for WATER and LAVA block types.

Fixes #21 