### PR TITLE
updating the version of bukkit server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.zhuoweizhang</groupId>
     <artifactId>raspberryjuice</artifactId>
-    <version>1.7</version>
+    <version>1.8.8-R0.1-SNAPSHOT</version>
     <name>RaspberryJuice</name>
     <repositories>
         <repository>
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.4.6-R0.4-SNAPSHOT</version>
+            <version>${project.version}</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/src/main/java/net/zhuoweizhang/raspberryjuice/RaspberryJuicePlugin.java
+++ b/src/main/java/net/zhuoweizhang/raspberryjuice/RaspberryJuicePlugin.java
@@ -88,10 +88,10 @@ public class RaspberryJuicePlugin extends JavaPlugin implements Listener {
 
 	public Player getNamedPlayer(String name) {
 		if (name == null) return null;
-		Player[] allPlayers = getServer().getOnlinePlayers();
-		for (int i = 0; i < allPlayers.length; ++i) {
-			if (name.equals(allPlayers[i].getPlayerListName())) {
-				return allPlayers[i];
+		Collection<? extends Player> allPlayers = getServer().getOnlinePlayers();
+		for (Player player: allPlayers) {
+			if (name.equals(player.getPlayerListName())) {
+				return player;
 			}
 		}
 		return null;
@@ -99,9 +99,9 @@ public class RaspberryJuicePlugin extends JavaPlugin implements Listener {
 
 	public Player getHostPlayer() {
 		if (hostPlayer != null) return hostPlayer;
-		Player[] allPlayers = getServer().getOnlinePlayers();
-		if (allPlayers.length >= 1)
-			return allPlayers[0];
+		Collection<? extends Player> allPlayers = getServer().getOnlinePlayers();
+		if (allPlayers.size() > 0)
+			return allPlayers.iterator().next();
 		return null;
 	}
 	


### PR DESCRIPTION
In RaspberryJuicePlugin, use latest bukkit server (1.8.8) and fix getNamedPlayer and getHostPlayer to update with the latest getOnlinePlayers() method