### PR TITLE
Upgraded the compiler to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.0.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>7</source>
+                    <target>7</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Currently the .pom file specifies the build source and target as Java 1.6, however this is very old and for me it causes a build error when I run `mvn package`:

    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD FAILURE
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  8.146 s
    [INFO] Finished at: 2019-08-16T09:04:41+01:00
    [INFO] ------------------------------------------------------------------------
    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project raspberryjuice: Compilation failure: Compilation failure:
    [ERROR] error: Source option 6 is no longer supported. Use 7 or later.
    [ERROR] error: Target option 6 is no longer supported. Use 7 or later.
    [ERROR] -> [Help 1]
    [ERROR]
    [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
    [ERROR] Re-run Maven using the -X switch to enable full debug logging.
    [ERROR]
    [ERROR] For more information about the errors and possible solutions, please read the following articles:
    [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

I've made the smallest change I could to fix the build, which was to configure the compiler to use Java 7.