### PR TITLE
Added multiple worldsupport

### DIFF
--- a/src/main/java/net/zhuoweizhang/raspberryjuice/RaspberryJuicePlugin.java
+++ b/src/main/java/net/zhuoweizhang/raspberryjuice/RaspberryJuicePlugin.java
@@ -50,10 +50,13 @@ public class RaspberryJuicePlugin extends JavaPlugin implements Listener {
 
 	public void onEnable() {
 		//save a copy of the default config.yml if one is not there
-        this.saveDefaultConfig();
-        //get host and port from config.yml
+    this.saveDefaultConfig();
+    //get host and port from config.yml
 		String hostname = this.getConfig().getString("hostname");
-		if (hostname == null || hostname.isEmpty()) hostname = "0.0.0.0";
+		if (hostname == null || hostname.isEmpty()) {
+			hostname = "0.0.0.0";
+			this.getConfig().set("hostname", "0.0.0.0");
+		}
 		int port = this.getConfig().getInt("port");
 		getLogger().info("Using host:port - " + hostname + ":" + Integer.toString(port));
 		
@@ -66,7 +69,15 @@ public class RaspberryJuicePlugin extends JavaPlugin implements Listener {
 			locationType = LocationType.valueOf("RELATIVE");
 		}
 		getLogger().info("Using " + locationType.name() + " locations");
+    
+    //get world (and set it to default if empty) from config.yml
+		String world = this.getConfig().getString("world");
+		if (world == null || world.isEmpty()) this.getConfig().set("world", getServer().getWorlds().get(0).getName());
+    this.saveConfig();
+    this.reloadConfig();
 
+    getLogger().info("Using " + world + " as the active world!");
+    
 		//get hit click type (LEFT, RIGHT or BOTH) from config.yml
 		String hitClick = this.getConfig().getString("hitclick").toUpperCase();
 		try {

--- a/src/main/java/net/zhuoweizhang/raspberryjuice/RemoteSession.java
+++ b/src/main/java/net/zhuoweizhang/raspberryjuice/RemoteSession.java
@@ -651,8 +651,12 @@ public class RemoteSession {
         }
         send(worldNames);
 				 
+			// getCurrentWorld
+			}else if (c.equals("getCurrentWorld")) {
+				send(world.getName());
+				
 			// setWorld
-			}
+			} 
 			
 			else if (c.equals("setWorld")) {
         if(worldNamesList.contains(args[0])) {
@@ -664,10 +668,8 @@ public class RemoteSession {
           
 					send(args[0] + " is not a valid world!");
 				}
-				
-			}
-			
-			else if (c.equals("player.getWorld")) {
+			//player.getWorld
+			}else if (c.equals("player.getWorld")) {
 
         Player currentPlayer = getCurrentPlayer();
 				send(currentPlayer.getWorld().getName());

--- a/src/main/java/net/zhuoweizhang/raspberryjuice/RemoteSession.java
+++ b/src/main/java/net/zhuoweizhang/raspberryjuice/RemoteSession.java
@@ -7,8 +7,10 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.Socket;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -170,7 +172,24 @@ public class RemoteSession {
 			Server server = plugin.getServer();
 			
 			// get the world
-			World world = origin.getWorld();
+      String worldString = plugin.getConfig().getString("world");
+      World world;
+      
+      List<World> worldsList = Bukkit.getWorlds();
+      List<String> worldNamesList = new ArrayList<String>();
+    
+			for(World w: worldsList){
+				worldNamesList.add(w.getName());			
+			}
+           
+      if((worldNamesList.contains(worldString)) && (worldString != null)) {
+				 world = plugin.getServer().getWorld(worldString);
+			} else {
+         world = plugin.getServer().getWorlds().get(0);
+         plugin.getConfig().set("world", world.getName());
+         plugin.saveConfig();
+         plugin.reloadConfig();
+      }
 			
 			// world.getBlock
 			if (c.equals("world.getBlock")) {
@@ -624,22 +643,34 @@ public class RemoteSession {
         
       //getWorlds
 			} else if (c.equals("getWorlds")) {
-				 send(Bukkit.getWorlds());
+           
+        String worldNames = "";
+				List<World> worlds = Bukkit.getWorlds();
+        for(World w: worlds){
+          worldNames += w.getName() + ",";
+        }
+        send(worldNames);
 				 
 			// setWorld
 			}
 			
 			else if (c.equals("setWorld")) {
+        if(worldNamesList.contains(args[0])) {
+					plugin.getConfig().set("world", args[0]);
+					plugin.saveConfig();
+					plugin.reloadConfig();
+					send("Set active world to " + args[0]);
+				} else {
+          
+					send(args[0] + " is not a valid world!");
+				}
 				
-        //send("Set world to " + args[0]);
-
-			// player.getWorld
 			}
 			
 			else if (c.equals("player.getWorld")) {
 
         Player currentPlayer = getCurrentPlayer();
-				send(currentPlayer.getWorld());
+				send(currentPlayer.getWorld().getName());
 
 			// not a command which is supported
 			} else {

--- a/src/main/java/net/zhuoweizhang/raspberryjuice/RemoteSession.java
+++ b/src/main/java/net/zhuoweizhang/raspberryjuice/RemoteSession.java
@@ -621,6 +621,25 @@ public class RemoteSession {
 					}
 				}
 				send(bdr.toString());
+        
+      //getWorlds
+			} else if (c.equals("getWorlds")) {
+				 send(Bukkit.getWorlds());
+				 
+			// setWorld
+			}
+			
+			else if (c.equals("setWorld")) {
+				
+        //send("Set world to " + args[0]);
+
+			// player.getWorld
+			}
+			
+			else if (c.equals("player.getWorld")) {
+
+        Player currentPlayer = getCurrentPlayer();
+				send(currentPlayer.getWorld());
 
 			// not a command which is supported
 			} else {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,5 +9,8 @@ port: 4711
 # Determine whether locations are RELATIVE to the spawn point (default like pi) or ABSOLUTE
 location: RELATIVE
 
+# Determine in what world RaspberryJuice will execute its commands
+world: 
+
 # Determine whether hit events are triggered by LEFT clicks, RIGHT clicks or BOTH
 hitclick: RIGHT

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,16 +1,13 @@
 # default config.yml
-
 # The host name and port to listen on
 # hostname - ip address or hostname to allow connections from, default is "0.0.0.0" 
 #            (any). "localhost" would prevent remote clients from connecting.
+# location determines whether locations are RELATIVE to the spawn point (default like pi) or ABSOLUTE
+# world determines in what world RaspberryJuice will execute its commands
+# hitclick determines whether hit events are triggered by LEFT clicks, RIGHT clicks or BOTH
+
 hostname: 
 port: 4711
-
-# Determine whether locations are RELATIVE to the spawn point (default like pi) or ABSOLUTE
 location: RELATIVE
-
-# Determine in what world RaspberryJuice will execute its commands
 world: 
-
-# Determine whether hit events are triggered by LEFT clicks, RIGHT clicks or BOTH
 hitclick: RIGHT

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,4 +4,4 @@ description: Implementation of the Minecraft PI modding API
 main: net.zhuoweizhang.raspberryjuice.RaspberryJuicePlugin
 name: RaspberryJuice
 startup: postworld
-version: '1.12.1'
+version: '1.13.0'


### PR DESCRIPTION
I added 4 commands in total: player.getWorld(), getWorlds(), getCurrentWorld() and setWorld(). This makes it possible to choose what world RaspberryJuice uses for it's commands involving location. I had to change the format of the config.yml because it got removed when the plugin wrote to it. I was thinking this maybe could be version 1.13.0? (I put it like that in the plugin.yml as well).