### PR TITLE
Fix Python 3.10 execution by replacing obsolete import

### DIFF
--- a/src/main/resources/mcpi/api/python/modded/mcpi/util.py
+++ b/src/main/resources/mcpi/api/python/modded/mcpi/util.py
@@ -1,8 +1,8 @@
-import collections
+import typing
 
 def flatten(l):
     for e in l:
-        if isinstance(e, collections.Iterable) and not isinstance(e, str):
+        if isinstance(e, typing.Iterable) and not isinstance(e, str):
             for ee in flatten(e): yield ee
         else: yield e
 


### PR DESCRIPTION
Fix Python 3.10 execution by addressing: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working